### PR TITLE
simple fix for running on Windows

### DIFF
--- a/csdap_bulk_download/csdap.py
+++ b/csdap_bulk_download/csdap.py
@@ -93,7 +93,7 @@ class CsdapClient:
         # Download
         logger.debug("Downloading %s...", path)
         response = requests.get(
-            f"{self.csdap_api_url}/v1/download/{path}",
+            f"{self.csdap_api_url}/v1/download/{path.as_posix()}",
             stream=True,
             headers={"authorization": f"Bearer {token}"},
         )


### PR DESCRIPTION
Hi. I work with Brad Quayle at GTAC. He was having some issues getting your program to run and asked for some help. After digging around a bit, I figured out that the download URI was being created incorrectly on Windows, with a couple parts using backslashes instead of forward slashes. Basically they ended up looking like this:

https://csdap.earthdata.nasa.gov/api/v1/download/368\utm11n_42_02_10m_v1.0\metadata.odl

Anyway, here's a one-line pull request to fix it, if you want. In my limited testing, it doesn't break anything on MacOS or Linux.

Thanks.