### PR TITLE
Check for empty dir before requesting file

### DIFF
--- a/csdap_bulk_download/csdap.py
+++ b/csdap_bulk_download/csdap.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 import textwrap
 import json
@@ -108,6 +109,9 @@ class CsdapClient:
     ) -> Path:
         # Prep file_dir
         file_dir = out_dir / path
+        # Skip if already exists
+        if file_dir.exists() and len(os.listdir(file_dir)):
+            return f"Skipped, files exist in {file_dir}"
         file_dir.mkdir(parents=True, exist_ok=True)
 
         # Download
@@ -133,10 +137,6 @@ class CsdapClient:
             if disposition_filename:
                 filename = disposition_filename[0]
         filepath = file_dir / filename
-
-        # Skip if already exists
-        if filepath.exists():
-            return f"Skipped, file exists at {filepath}"
 
         # Write to local disk
         stream = response.iter_content(chunk_size=8192)


### PR DESCRIPTION
It appears that our logic to avoid redundant downloads was somewhat incorrect.  


Instead of making the request and then determining if the file exists on disk before we write to disk, we should ensure that the file isn't present _before_ making the request.  This will avoid duplicate counts against a user's quota and additionally result in less requests made to our API/files.  

There's a bit of a shortcoming here where we don't know the exact output filename until we make the request, so we can't ensure that the exact file that would be downloaded has been downloaded.  Instead, this code change makes the assumption that if there are _any_ files in the destination directory, then there is no need to download the file.  This seemed reasonable as the `path` is based on the item's `scene_id` + `asset_type`, which should be unique.

https://github.com/NASA-IMPACT/csdap-bulk-download/blob/5169cfffd12de2dfcc79332a57ff1c9f14202888/csdap_bulk_download/cli.py#L126

Moving forward, it may make sense to support `HEAD` requests made to our API to get metadata about the files (filesize, checksum, filename) which could be performed before the download.  This could allow us to have more intelligent logic when determining if a file should be downloaded (ie handle situations where the download script crashes mid-download, thus overwriting partially downloaded files).

Resolves #23