### PR TITLE
Bugfix/avoid memory issues

### DIFF
--- a/csdap_bulk_download/cli.py
+++ b/csdap_bulk_download/cli.py
@@ -123,7 +123,7 @@ def cli(
             try:
                 logger.info("%s: %s", path, future.result())
             except Exception as exc:
-                if verbosity > 1:
+                if verbosity:
                     logger.exception("%s generated an exception: %s" % (path, exc))
                 else:
                     logger.warn("%s: Failed to download", path)

--- a/csdap_bulk_download/cli.py
+++ b/csdap_bulk_download/cli.py
@@ -112,6 +112,8 @@ def cli(
     with concurrent.futures.ThreadPoolExecutor(
         max_workers=concurrency, thread_name_prefix="CsdapDownload"
     ) as executor:
+        logger.debug(
+            "Creating threadpool with max_workers of %s", executor._max_workers)
         future_to_path = {}
         for input_csv in input_csvs:
             api_version = 2
@@ -146,7 +148,7 @@ def cli(
         # Log results
         with logging_redirect_tqdm():
             for future in concurrent.futures.as_completed(future_to_path):
-                path = future_to_path[future]
+                path = future_to_path.pop(future)
                 try:
                     logger.info("%s: %s", path, future.result())
                 except Exception as exc:

--- a/csdap_bulk_download/csdap.py
+++ b/csdap_bulk_download/csdap.py
@@ -142,7 +142,7 @@ class CsdapClient:
                 total=int(response.headers.get("content-size", 0)),
                 unit="iB",
                 unit_scale=True,
-                desc=f"Downloading {filepath}",
+                desc=f"Downloading {filepath.name}",
                 dynamic_ncols=True,
                 leave=False,
             )


### PR DESCRIPTION
In response to #22, this PR makes three changes:

1. When processing the CSV, the script now will wait for items to finish before scheduling more futures if the length of outstanding work is greater than 2 times the max number of workers
2. When a future completes, the future is removed from our lookup table as it is logged
3. Use the `request.get` as a context manager to ensure that it gets cleaned up after usage. Honestly, I don't think this was necessary, however I don't think it hurts...

I believe this should ensure that there are never an absurd amount of futures scheduled and stored in our lookup table when processing massive CSVs.

Closes #22 